### PR TITLE
Adds sanitize wrapper for shell execution for sensitive information

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ usage:
 await quiet($`echo foobar`); // command and output will not be displayed.
 ```
 
+`sanitize()` Changes the behaviour of `$` to redact output.
+
+usage:
+
+```ts
+await sanitize($`echo a SECRET_KEY`, ['SECRET_KEY']);
+> a ********
+```
+
 `os` package.
 
 usage:

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -16,6 +16,7 @@ import {
   quietInternal,
   retryInternal,
   rmrfInternal,
+  sanitizeInternal,
   sleepInternal,
   startSpinnerInternal,
 } from "./index.ts";
@@ -33,6 +34,7 @@ declare global {
   const Colors: typeof ColorsInternal;
   const sleep: typeof sleepInternal;
   const quiet: typeof quietInternal;
+  const sanitize: typeof sanitizeInternal;
   const retry: typeof retryInternal;
   const startSpinner: typeof startSpinnerInternal;
 }

--- a/vl.test.ts
+++ b/vl.test.ts
@@ -79,6 +79,13 @@ Deno.test("quiet() works", async () => {
   await p;
 });
 
+Deno.test("santitize() works", async () => {
+  const p = sanitize($`echo "hello" SECRET_KEY`, ["SECRET_KEY"]);
+  assertEquals(p._sanitize, ["SECRET_KEY"]);
+  // Note that sanitize stopped it from printing but does not remove it from the output of stdout
+  await p;
+});
+
 Deno.test("retry works", async () => {
   let exitCode = 0;
   const now = Date.now();


### PR DESCRIPTION
Hello!

I've been happily using vl as my tooling alternative to bash for non-trivial scripts :).

This PR adds sanitize for the case where output is desireable but a secret token needs to be passed on the commandline and it's undesireably for security to show the secret token.

`sanitize` allows for selective redacting of output by supplying a second argument which is a list of strings to redact.

```ts
await sanitize($`echo a SECRET_KEY`, ['SECRET_KEY']);
```

Alternatives considered:
In the past with zx, I've used quiet() but in this case quiet means my terminal doesn't receive control of an interactive shell that is the command I'm executing. I worked around it by embedding ENV vars with the secret but it's brittle due to quoting behaviour. (Project: https://github.com/zph/msh/blob/main/main.ts#L147)

Implementation:
I copied the structure and behavior of `quiet` in the codebase.

Let me know if you see adjustments or improvements you'd like and than you for reviewing!
