### PR TITLE
String format of shell execution fails when > 1 variable included

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -213,14 +213,14 @@ export class ProcessOutput extends Error {
 export const $Internal: $Internal = (pieces, ...args) => {
   const { verbose, shell, prefix, spawn } = $Internal;
 
-  const cmd = args
+  const argsQuoted = args
     .map((p) =>
       Array.isArray(p)
         // deno-lint-ignore no-explicit-any
         ? p.map((a: any) => $Internal.quote(substitute(a))).join(" ")
         : $Internal.quote(substitute(p))
-    )
-    .reduce((acc, x) => `${acc}${x}`, pieces[0]);
+    );
+  const cmd = String.raw({ raw: pieces }, ...argsQuoted);
 
   // deno-lint-ignore no-explicit-any
   let resolve: any, reject: any;

--- a/vl.test.ts
+++ b/vl.test.ts
@@ -49,20 +49,20 @@ Deno.test("undefined and empty string correctly quoted", async () => {
 });
 
 Deno.test("multiple arguments in execution are correctly quoted from list format", async () => {
-  let foo = "foo"
-  let bar = "bar"
+  let foo = "foo";
+  let bar = "bar";
   let cmd = [
     `echo`,
     foo,
     "to",
-    bar
-  ]
+    bar,
+  ];
   assertEquals((await $`${cmd}`).stdout.trim(), "foo to bar");
 });
 
 Deno.test("multiple arguments in execution are correctly quoted from string format", async () => {
-  let foo = "foo"
-  let bar = "bar"
+  let foo = "foo";
+  let bar = "bar";
   assertEquals((await $`echo ${foo} to ${bar}`).stdout.trim(), "foo to bar");
   assertEquals((await $`echo ${foo}:${bar}`).stdout.trim(), "foo:bar");
 });

--- a/vl.test.ts
+++ b/vl.test.ts
@@ -48,6 +48,13 @@ Deno.test("undefined and empty string correctly quoted", async () => {
   assertEquals((await $`echo ${""}`).stdout.trim(), "");
 });
 
+Deno.test("multiple arguments in execution are correctly quoted", async () => {
+  let foo = "foo"
+  let bar = "bar"
+  assertEquals((await $`echo ${foo} to ${bar}`).stdout.trim(), "foo to bar");
+  assertEquals((await $`echo ${foo}:${bar}`).stdout.trim(), "foo:bar");
+});
+
 Deno.test("Can create a dir with a space in the name", async () => {
   const name = "foo bar";
   try {

--- a/vl.test.ts
+++ b/vl.test.ts
@@ -48,7 +48,19 @@ Deno.test("undefined and empty string correctly quoted", async () => {
   assertEquals((await $`echo ${""}`).stdout.trim(), "");
 });
 
-Deno.test("multiple arguments in execution are correctly quoted", async () => {
+Deno.test("multiple arguments in execution are correctly quoted from list format", async () => {
+  let foo = "foo"
+  let bar = "bar"
+  let cmd = [
+    `echo`,
+    foo,
+    "to",
+    bar
+  ]
+  assertEquals((await $`${cmd}`).stdout.trim(), "foo to bar");
+});
+
+Deno.test("multiple arguments in execution are correctly quoted from string format", async () => {
   let foo = "foo"
   let bar = "bar"
   assertEquals((await $`echo ${foo} to ${bar}`).stdout.trim(), "foo to bar");


### PR DESCRIPTION
Hello again!

I added a succeeding test and a failing test to demonstrate that when using the list form of shell interpolation, it works and when using the string form with > 1 argument, it yields unexpected results.

See below for debug output from the added tests:

```
multiple arguments in execution are correctly quoted from list format ...
------- output -------
{ pieces: [ "", "" ], args: [ [ "echo", "foo", "to", "bar" ] ] }
echo foo to bar
{ acc: "", x: "echo foo to bar" }
{ cmd: "echo foo to bar" }
$ echo foo to bar
foo to bar
----- output end -----
multiple arguments in execution are correctly quoted from list format ... ok (11ms)
multiple arguments in execution are correctly quoted from string format ...
------- output -------
{ pieces: [ "echo ", " to ", "" ], args: [ "foo", "bar" ] }
foo
bar
{ acc: "echo ", x: "foo" }
{ acc: "echo foo", x: "bar" }
{ cmd: "echo foobar" }
$ echo foobar
foobar
----- output end -----
multiple arguments in execution are correctly quoted from string format ... FAILED (11ms)
```

It's failing in the reduce statement here: https://github.com/japiirainen/vl/blob/main/index.ts#L223 because it's not threading the `pieces` and the `args` back together. It's appending the args without incrementing a counter for the pieces index.

I'm unsure how you want to fix it and so far my thoughts have gone towards more involved fixes that maintain the index position of where the args existed before split out. Instead I thought it sensible to raise the error with a good test case to see if you have a preferred approach.

If you prefer the templating or accounting of where variables exist in statements, I'm happy to take a pass at implementing.